### PR TITLE
fix: enable terraform single-phase deployment by switching to kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,45 +207,29 @@ git clone https://github.com/LondheShubham153/retail-store-sample-app.git
 
 ### Step 4. Deploy Infrastructure with Terraform:
 
-The deployment is split into two phases for better control:
-
-
-### Phase 1 of Terraform: Create EKS Cluster 
-
-In Phase 1: Terraform Initialises and creates resources within the retail_app_eks module. 
-
 ```sh
 cd retail-store-sample-app/terraform/
 terraform init
-terraform apply -target=module.retail_app_eks -target=module.vpc --auto-approve
+terraform apply --auto-approve
 ```
 
 <img width="1205" height="292" alt="image" src="https://github.com/user-attachments/assets/6f1e407e-4a4e-4a4c-9bdf-0c9b89681368" />
-
 
 This creates the core infrastructure, including:
 - VPC with public and private subnets
 - Amazon EKS cluster with Auto Mode enabled
 - Security groups and IAM roles
-  
 
-### Step 6: Update kubeconfig to Access the Amazon EKS Cluster:
-```
-aws eks update-kubeconfig --name retail-store --region <region>
-```
-
-### Phase 2 of Terraform: Once you update kubeconfig, apply the Remaining Configuration:
-
-
-```bash
-terraform apply --auto-approve
-```
-
-
-This deploys:
+And deploys:
 - ArgoCD for Setup GitOps
 - NGINX Ingress Controller
 - Cert Manager for SSL certificates
+
+
+### Step 5: Update kubeconfig to Access the Amazon EKS Cluster:
+```
+aws eks update-kubeconfig --name retail-store --region <region>
+```
 
 > Application is live with Public image:
 
@@ -257,7 +241,7 @@ This deploys:
 > [!NOTE]
 > Let's move forward with GitOps principle utilising Amazon private registry to create private registry and store images.
 
-### Step 7: GitHub Actions (Production Branch Only)
+### Step 6: GitHub Actions (Production Branch Only)
 
 > **Note**: This step is only required if you're using the **Production branch** for automated deployments. Skip this step if using the **Public Application branch** for simple deployment.
 
@@ -295,7 +279,7 @@ Check if the nodes are running:
 kubectl get nodes
 ```
 
-### Step 8: Access the Application:
+### Step 7: Access the Application:
 
 The application is exposed through the NGINX Ingress Controller. Get the load balancer URL:
 
@@ -307,7 +291,7 @@ Use the EXTERNAL-IP of the ingress-nginx-controller service to access the applic
 
 <img width="2912" height="1756" alt="image" src="https://github.com/user-attachments/assets/095077d6-d3cb-48f6-b021-e977db5fb242" />
 
-### Step 9: Argo CD Automated Deployment:
+### Step 8: Argo CD Automated Deployment:
 
 **Verify ArgoCD installation**
 
@@ -316,7 +300,7 @@ kubectl get pods -n argocd
 ```
 
 
-### Step 10: Port-forward to Argo CD UI and login:
+### Step 9: Port-forward to Argo CD UI and login:
 
 **Get ArgoCD admin password**
 ```
@@ -355,17 +339,7 @@ kubectl get ingress -n retail-store
 ```
 
 ### Step 12: Cleanup
-
 To delete all resources created by Terraform:
-
-
-**For Phase 1: Run this command**
-
-```bash
-terraform destroy -target=module.retail_app_eks --auto-approve
-```
-
-**For Phase 2: Run this command**
 ```
 terraform destroy --auto-approve
 ```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,30 +39,6 @@ vim terraform.tfvars
 
 ### 3. Deploy Infrastructure
 
-You can deploy in two phases for better control:
-
-#### Phase 1: Deploy EKS Cluster Only
-```bash
-# Initialize Terraform
-terraform init
-
-# Deploy only the EKS cluster and VPC
-terraform apply -target=module.retail_app_eks -target=module.vpc --auto-approve
-```
-
-#### Phase 2: Deploy Add-ons and ArgoCD
-```bash
-# Get the actual cluster name (with suffix)
-terraform output cluster_name
-
-# Update kubeconfig to access the cluster (use the output from above)
-aws eks update-kubeconfig --region <aws region> --name <cluster-name-with-suffix>
-
-# Deploy the remaining components
-terraform apply --auto-approve
-```
-
-#### Single Phase Deployment (Alternative)
 ```bash
 # Initialize Terraform
 terraform init

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -14,17 +14,13 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14"
     }
     time = {
       source  = "hashicorp/time"
       version = ">= 0.9"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 3.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -53,7 +49,7 @@ provider "helm" {
   }
 }
 
-provider "kubernetes" {
+provider "kubectl" {
   host                   = module.retail_app_eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.retail_app_eks.cluster_certificate_authority_data)
   exec {


### PR DESCRIPTION
The single-phase deployment path was failing because the Kubernetes provider requires the cluster to be fully ready during `terraform plan`. This constraint aligned with multi-phase deployment (since infra was already up by then) but broke single-phase deployment.

By switching to the `kubectl` provider, which does not require the cluster to exist at plan time, single-phase deployment now works as expected.

>All changes have been tested and verified.

**Changes**

* Replaced `kubernetes` provider usage with `kubectl`.

**Why?**

* The Kubernetes provider enforces cluster availability at `plan` time.
* The kubectl provider only requires the cluster at `apply`, allowing a true single-phase workflow.

**Impacts**

* ✅ Single-phase deployment is now fully functional.
* ⚡ Reduced `terraform apply` time compared to previous setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Shifted from time-based waits to manifest-driven deployments for ArgoCD, improving reliability and determinism.
  - Separated deployment flow for projects and applications with clear dependencies to ensure correct ordering.
- Chores
  - Standardized on manifest-based tooling for cluster changes, simplifying configuration.
  - Removed legacy wait and redeploy mechanisms tied to timers and local commands.
  - Updated section labeling to better reflect ArgoCD configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->